### PR TITLE
[Enhancement] Add `CITATION.cff` (#1)

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2021 Stephan Druskat <mail@sdruskat.net>
+# SPDX-License-Identifier: CC0-1.0
+
+name: cffconvert
+
+on:
+  push:
+    paths:
+      - CITATION.cff
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          persist-credentials: false
+
+      - name: cffconvert
+        uses: citation-file-format/cffconvert-github-action@4cf11baa70a673bfdf9dad0acc7ee33b3f4b6084
+        with:
+          args: "--validate"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2021 Stephan Druskat <mail@sdruskat.net>
+# SPDX-License-Identifier: CC0-1.0
+
+abstract: Tracks `CITATION.cff` files across public repositories.
+authors:
+  - family-names: Druskat
+    given-names: Stephan
+    orcid: https://orcid.org/0000-0003-4925-7248
+cff-version: 1.2.0
+license:
+  - CC0-1.0
+  - CC-BY-4.0
+  - MIT
+message: Please cite this repository using these meta data.
+repository-artifact: https://github.com/sdruskat/cfftracker
+repository-code: https://github.com/sdruskat/cfftracker
+title: cfftracker
+type: dataset
+url: https://github.com/sdruskat/cfftracker


### PR DESCRIPTION
This Pull Request adds a `CITATION.cff` as well as its automatic validation to this repository.  Since this repository is related to the CFF standard, it should also contain a `CITATION.cff` since it might be an interesting source of statistics for a publication about CFF.

I derived the author information from the CFF main repository and added some further settings derived from this one.  If I shall change some of them, please tell me.

For instance, I added all applied licenses to the `license` section.  By the way, GitHub has also a multi-license mechanism where one superior configuration file can contain information about which license has to be applied when.  Hence, I decided to add all contained licenses to the initial setup.